### PR TITLE
chore: repo maintenance - fix renovate config, upgrade zod v4 and @types/node v24

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,12 +22,12 @@
         "superjson": "2.2.2",
         "ts3-nodejs-library": "3.5.1",
         "usehooks-ts": "3.1.1",
-        "zod": "3.25.76",
+        "zod": "^4.1.5",
       },
       "devDependencies": {
         "@biomejs/biome": "2.2.2",
         "@tailwindcss/postcss": "4.1.12",
-        "@types/node": "22.18.0",
+        "@types/node": "^24.3.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "postcss": "8.5.6",
@@ -205,7 +205,7 @@
 
     "@trpc/tanstack-react-query": ["@trpc/tanstack-react-query@11.8.0", "", { "peerDependencies": { "@tanstack/react-query": "^5.80.3", "@trpc/client": "11.8.0", "@trpc/server": "11.8.0", "react": ">=18.2.0", "react-dom": ">=18.2.0", "typescript": ">=5.7.2" } }, "sha512-LtLVyYzv5MjviBUElkCn1X246BCcq2j58N7mNxg4IqaR9Uvw9y7q6VdJMo5jWO9XogBVltgvHc5sZCJ+7IE1NQ=="],
 
-    "@types/node": ["@types/node@22.18.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ=="],
+    "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -319,13 +319,13 @@
 
     "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "usehooks-ts": ["usehooks-ts@3.1.1", "", { "dependencies": { "lodash.debounce": "^4.0.8" }, "peerDependencies": { "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.4.5", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.4", "tslib": "^2.4.0" }, "bundled": true }, "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "superjson": "2.2.2",
     "ts3-nodejs-library": "3.5.1",
     "usehooks-ts": "3.1.1",
-    "zod": "3.25.76"
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",
     "@tailwindcss/postcss": "4.1.12",
-    "@types/node": "22.18.0",
+    "@types/node": "^24.3.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "postcss": "8.5.6",

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "groupName": "tanstack",
+      "matchPackageNames": ["@tanstack/**"]
     }
   ],
   "schedule": ["every weekend"],
@@ -26,11 +30,5 @@
   "vulnerabilityAlerts": {
     "labels": ["security"],
     "automerge": false
-  },
-  "packageGroups": [
-    {
-      "groupName": "tanstack",
-      "packages": ["@tanstack/*"]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

- Fixes #147 — `renovate.json` used the removed `packageGroups` key (grouping now lives inside `packageRules`), which was the actual reason Renovate had stopped opening PRs. Moved the `tanstack` grouping into a `packageRules` entry with `matchPackageNames`, and validated the file with `renovate-config-validator` (passes clean now).
- Closes #115 — bump `zod` 3.25.76 → 4.4.3. Only two files use zod directly (`src/env.js`, `src/server/api/trpc.ts`); `ZodError.flatten()` usage is unaffected by v4.
- Closes #87 — bump `@types/node` 22.18.0 → 24.13.3 (devDependency only).

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run build` passes (with dummy `TS3_*` env vars)
- [x] `renovate-config-validator renovate.json` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuuJ6cvehHEbpqgmPN1Kx6)_